### PR TITLE
add update function for service instance

### DIFF
--- a/internal/controller/serviceinstance/serviceinstance.go
+++ b/internal/controller/serviceinstance/serviceinstance.go
@@ -310,8 +310,6 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		if resp.OperationKey != nil {
 			si.Status.AtProvider.LastOperationKey = *resp.OperationKey
 		}
-	} else {
-		si.Status.AtProvider.LastOperationState = osb.StateSucceeded
 	}
 	// Update the status of the ServiceInstance resource in Kubernetes.
 	if err := c.kube.Status().Update(ctx, si); err != nil {


### PR DESCRIPTION
This Pull Request introduces the implementation of the Update function in the ServiceInstance reconciler.
The Update fucntion is responsible for :
- Detecting configuration changes between the desired state and the current state of the OBS instance.
- Sending an update request the OSB API when a modification is required(e.g., plan change, parameters update).
- Handling asynchronous responses from the broker and updating the ressource status accordingly.