### PR TITLE
Handle asynchronous operations in Observe function for ServiceInstance

### DIFF
--- a/apis/instance/v1alpha1/serviceinstance_types.go
+++ b/apis/instance/v1alpha1/serviceinstance_types.go
@@ -31,14 +31,15 @@ import (
 // ServiceInstanceObservation are the observable fields of a ServiceInstance.
 // TODO manage observations
 type ServiceInstanceObservation struct {
-	ApplicationRef      *common.NamespacedName  `json:"application,omitempty"`
-	ApplicationData     *common.ApplicationData `json:"applicationData,omitempty"`
-	common.InstanceData `json:",inline"`
-	Context             common.KubernetesOSBContext `json:"context,omitempty"`
-	DashboardURL        *string                     `json:"dashboardURL,omitempty"`
-	LastOperationState  osb.LastOperationState      `json:"last_operation_state,omitempty"`
-	LastOperationKey    osb.OperationKey            `json:"last_operation_key,omitempty"`
-	HasActiveBindings   bool                        `json:"hasActiveBindings,omitempty"`
+	ApplicationRef           *common.NamespacedName  `json:"application,omitempty"`
+	ApplicationData          *common.ApplicationData `json:"applicationData,omitempty"`
+	common.InstanceData      `json:",inline"`
+	Context                  common.KubernetesOSBContext `json:"context,omitempty"`
+	DashboardURL             *string                     `json:"dashboardURL,omitempty"`
+	LastOperationState       osb.LastOperationState      `json:"last_operation_state,omitempty"`
+	LastOperationKey         osb.OperationKey            `json:"last_operation_key,omitempty"`
+	LastOperationDescription string                      `json:"last_operation_description,omitempty"`
+	HasActiveBindings        bool                        `json:"hasActiveBindings,omitempty"`
 }
 
 // A ServiceInstanceSpec defines the desired state of a ServiceInstance.

--- a/internal/controller/serviceinstance/serviceinstance.go
+++ b/internal/controller/serviceinstance/serviceinstance.go
@@ -420,7 +420,9 @@ func (c *external) handleLastOperationInProgress(ctx context.Context, si *v1alph
 		si.Status.SetConditions(xpv1.Available())
 	case osb.StateFailed:
 		si.Status.SetConditions(xpv1.Unavailable())
+	default: // already defined InProgress
 	}
+
 	// Update the status of the ServiceInstance resource in Kubernetes.
 	if err := c.kube.Status().Update(ctx, si); err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot update ServiceInstance status")

--- a/internal/controller/serviceinstance/serviceinstance.go
+++ b/internal/controller/serviceinstance/serviceinstance.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+
 	osb "github.com/orange-cloudfoundry/go-open-service-broker-client/v2"
 	apisbinding "github.com/orange-cloudfoundry/provider-osb/apis/binding/v1alpha1"
 	"github.com/orange-cloudfoundry/provider-osb/apis/common"
@@ -415,14 +416,12 @@ func (c *external) handleLastOperationInProgress(ctx context.Context, si *v1alph
 	}
 
 	// Operation has completed (succeeded or failed), update the status accordingly.
-	switch resp.State {
-	case osb.StateSucceeded:
+	if resp.State == osb.StateSucceeded {
 		si.Status.SetConditions(xpv1.Available())
-	case osb.StateFailed:
-		si.Status.SetConditions(xpv1.Unavailable())
-	default: // already defined InProgress
 	}
-
+	if resp.State == osb.StateFailed {
+		si.Status.SetConditions(xpv1.Unavailable())
+	}
 	// Update the status of the ServiceInstance resource in Kubernetes.
 	if err := c.kube.Status().Update(ctx, si); err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot update ServiceInstance status")

--- a/package/crds/instance.osb.crossplane.io_serviceinstances.yaml
+++ b/package/crds/instance.osb.crossplane.io_serviceinstances.yaml
@@ -384,6 +384,8 @@ spec:
                     type: boolean
                   instanceId:
                     type: string
+                  last_operation_description:
+                    type: string
                   last_operation_key:
                     description: |-
                       OperationKey is an extra identifier from the broker in order to provide extra


### PR DESCRIPTION
This Pull Request enhances the Observe function to properly handle asynchronous operations when interacting with the the OSB API.
The updated Observe function is responsible for :
- Detecting when a ServiceInstance is in an in-progress state(e,g., provisionning, updating, or deleting).
- Polling the OSB API LastOperation endpoint to check the current status of the operation.
- Updating the crossplane ressource status with the latest operation state(InProgress, Succeeded, or Failed).