### PR TITLE
fix: fix managed resources apigroups REF: #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ spec:
 **ServiceInstance**: A resource representing a provisioned instance of an external service, such as a database, cache, or other cloud service.
 
 ```yaml
-apiVersion: instance.m.osb.crossplane.io/v1alpha1
+apiVersion: instance.osb.m.crossplane.io/v1alpha1
 kind: ServiceInstance
 metadata:
   name: my-db-instance
@@ -76,7 +76,7 @@ spec:
 **ServiceBinding**: A resource that establishes a connection between an Application and a ServiceInstance. It provides the application with the necessary information (such as credentials or secrets) to access the external service.
 
 ```yaml
-apiVersion:  binding.m.osb.crossplane.io/v1alpha1
+apiVersion:  binding.osb.m.crossplane.io/v1alpha1
 kind: ServiceBinding
 metadata:
   name: my-db-binding

--- a/apis/binding/v1alpha1/doc.go
+++ b/apis/binding/v1alpha1/doc.go
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Package v1alpha1 contains the v1alpha1 group ServiceBinding resources of the OSB provider.
 // +kubebuilder:object:generate=true
-// +groupName=binding.m.osb.crossplane.io
+// +groupName=binding.osb.m.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1

--- a/apis/binding/v1alpha1/groupversion_info.go
+++ b/apis/binding/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains the v1alpha1 group Sample resources of the osb provider.
 // +kubebuilder:object:generate=true
-// +groupName=binding.m.osb.crossplane.io
+// +groupName=binding.osb.m.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -27,7 +27,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "binding.m.osb.crossplane.io"
+	Group   = "binding.osb.m.crossplane.io"
 	Version = "v1alpha1"
 )
 

--- a/apis/binding/v1alpha1/servicebinding_methods.go
+++ b/apis/binding/v1alpha1/servicebinding_methods.go
@@ -12,7 +12,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	osbClient "github.com/orange-cloudfoundry/go-open-service-broker-client/v2"
 	v1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/apis/instance/v1alpha1/doc.go
+++ b/apis/instance/v1alpha1/doc.go
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Package v1alpha1 contains the v1alpha1 group ServiceInstance resources of the OSB provider.
 // +kubebuilder:object:generate=true
-// +groupName=instance.m.osb.crossplane.io
+// +groupName=instance.osb.m.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1

--- a/apis/instance/v1alpha1/groupversion_info.go
+++ b/apis/instance/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains the v1alpha1 group Sample resources of the osb provider.
 // +kubebuilder:object:generate=true
-// +groupName=instance.m.osb.crossplane.io
+// +groupName=instance.osb.m.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -27,7 +27,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "instance.m.osb.crossplane.io"
+	Group   = "instance.osb.m.crossplane.io"
 	Version = "v1alpha1"
 )
 

--- a/apis/v1alpha1/groupversion_info.go
+++ b/apis/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains the core resources of the osb provider.
 // +kubebuilder:object:generate=true
-// +groupName=m.osb.crossplane.io
+// +groupName=osb.m.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -27,7 +27,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "m.osb.crossplane.io"
+	Group   = "osb.m.crossplane.io"
 	Version = "v1alpha1"
 )
 

--- a/package/crds/binding.osb.m.crossplane.io_servicebindings.yaml
+++ b/package/crds/binding.osb.m.crossplane.io_servicebindings.yaml
@@ -4,18 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: serviceinstances.instance.m.osb.crossplane.io
+  name: servicebindings.binding.osb.m.crossplane.io
 spec:
-  group: instance.m.osb.crossplane.io
+  group: binding.osb.m.crossplane.io
   names:
     categories:
     - crossplane
     - managed
     - osb
-    kind: ServiceInstance
-    listKind: ServiceInstanceList
-    plural: serviceinstances
-    singular: serviceinstance
+    kind: ServiceBinding
+    listKind: ServiceBindingList
+    plural: servicebindings
+    singular: servicebinding
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -34,7 +34,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServiceInstance is the managed OSB resource
+        description: A ServiceBinding is an example API type.
         properties:
           apiVersion:
             description: |-
@@ -54,10 +54,11 @@ spec:
           metadata:
             type: object
           spec:
+            description: A ServiceBindingSpec defines the desired state of a ServiceBinding.
             properties:
               forProvider:
-                description: Instance Data represents the schema for a ServiceInstance
-                  MR
+                description: ServiceBindingParameters are the configurable fields
+                  of a ServiceBinding.
                 properties:
                   appGuid:
                     type: string
@@ -97,10 +98,6 @@ spec:
                     - platform
                     type: object
                   instanceId:
-                    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
-                    type: string
-                  organizationGuid:
-                    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
                     type: string
                   parameters:
                     description: |-
@@ -109,19 +106,12 @@ spec:
                       It is stored as a string but can be converted back to a Go map.
                     type: string
                   planId:
-                    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
+                    type: string
+                  route:
+                    pattern: ^https?://.+
                     type: string
                   serviceId:
                     type: string
-                  spaceGuid:
-                    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
-                    type: string
-                required:
-                - instanceId
-                - organizationGuid
-                - planId
-                - serviceId
-                - spaceGuid
                 type: object
               managementPolicies:
                 default:
@@ -182,52 +172,18 @@ spec:
             - forProvider
             type: object
           status:
+            description: A ServiceBindingStatus represents the observed state of a
+              ServiceBinding.
             properties:
               atProvider:
+                description: ServiceBindingObservation are the observable fields of
+                  a ServiceBinding.
                 properties:
-                  appGuid:
-                    type: string
-                  context:
+                  endpoints:
                     description: |-
-                      KubernetesOSBContext represents the context object for kubernetes in the OSB spec
-                      cf https://github.com/cloudfoundry/servicebroker/blob/master/profile.md#kubernetes-context-object
-                    properties:
-                      clusterId:
-                        type: string
-                      instanceAnnotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      instanceName:
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                        type: string
-                      namespace:
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                        type: string
-                      namespaceAnnotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      platform:
-                        enum:
-                        - kubernetes
-                        type: string
-                    required:
-                    - clusterId
-                    - instanceName
-                    - namespace
-                    - platform
-                    type: object
-                  dashboardURL:
-                    pattern: ^https?://.+
-                    type: string
-                  hasActiveBindings:
-                    type: boolean
-                  instanceId:
+                      SerializableEndpoints represents a JSON-encoded slice of endpoints.
+                      Stored as a string because slices are not directly serializable in Go.
+                      It is stored as a string but can be converted back to a slice of Endpoints.
                     type: string
                   lastOperationDescription:
                     type: string
@@ -236,24 +192,37 @@ spec:
                       OperationKey is an extra identifier from the broker in order to provide extra
                       identifiers for asynchronous operations.
                     type: string
+                  lastOperationPolled_time:
+                    type: string
                   lastOperationState:
                     description: |-
                       LastOperationState is a typedef representing the state of an ongoing
                       operation for an instance.
                     type: string
-                  organizationGuid:
-                    type: string
+                  metadata:
+                    properties:
+                      expires_at:
+                        type: string
+                      renew_before:
+                        type: string
+                    type: object
                   parameters:
                     description: |-
                       SerializableParameters represents a JSON-encoded map of arbitrary parameters.
                       Stored as a string because slices and maps are not directly serializable in Go
                       It is stored as a string but can be converted back to a Go map.
                     type: string
-                  planId:
+                  routeServiceUrl:
+                    pattern: ^https?://.+
                     type: string
-                  serviceId:
+                  syslogDrainUrl:
+                    pattern: ^https?://.+
                     type: string
-                  spaceGuid:
+                  volumeMounts:
+                    description: |-
+                      SerializableVolumeMounts represents a JSON-encoded slice of osb.VolumeMount.
+                      Stored as a string because slices are not directly serializable in Go.
+                      It is stored as a string but can be converted back to a slice of VolumeMounts.
                     type: string
                 type: object
               conditions:

--- a/package/crds/instance.osb.m.crossplane.io_serviceinstances.yaml
+++ b/package/crds/instance.osb.m.crossplane.io_serviceinstances.yaml
@@ -4,18 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: servicebindings.binding.m.osb.crossplane.io
+  name: serviceinstances.instance.osb.m.crossplane.io
 spec:
-  group: binding.m.osb.crossplane.io
+  group: instance.osb.m.crossplane.io
   names:
     categories:
     - crossplane
     - managed
     - osb
-    kind: ServiceBinding
-    listKind: ServiceBindingList
-    plural: servicebindings
-    singular: servicebinding
+    kind: ServiceInstance
+    listKind: ServiceInstanceList
+    plural: serviceinstances
+    singular: serviceinstance
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -34,7 +34,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ServiceBinding is an example API type.
+        description: ServiceInstance is the managed OSB resource
         properties:
           apiVersion:
             description: |-
@@ -54,11 +54,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: A ServiceBindingSpec defines the desired state of a ServiceBinding.
             properties:
               forProvider:
-                description: ServiceBindingParameters are the configurable fields
-                  of a ServiceBinding.
+                description: Instance Data represents the schema for a ServiceInstance
+                  MR
                 properties:
                   appGuid:
                     type: string
@@ -98,6 +97,10 @@ spec:
                     - platform
                     type: object
                   instanceId:
+                    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
+                    type: string
+                  organizationGuid:
+                    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
                     type: string
                   parameters:
                     description: |-
@@ -106,12 +109,19 @@ spec:
                       It is stored as a string but can be converted back to a Go map.
                     type: string
                   planId:
-                    type: string
-                  route:
-                    pattern: ^https?://.+
+                    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
                     type: string
                   serviceId:
                     type: string
+                  spaceGuid:
+                    pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
+                    type: string
+                required:
+                - instanceId
+                - organizationGuid
+                - planId
+                - serviceId
+                - spaceGuid
                 type: object
               managementPolicies:
                 default:
@@ -172,18 +182,52 @@ spec:
             - forProvider
             type: object
           status:
-            description: A ServiceBindingStatus represents the observed state of a
-              ServiceBinding.
             properties:
               atProvider:
-                description: ServiceBindingObservation are the observable fields of
-                  a ServiceBinding.
                 properties:
-                  endpoints:
+                  appGuid:
+                    type: string
+                  context:
                     description: |-
-                      SerializableEndpoints represents a JSON-encoded slice of endpoints.
-                      Stored as a string because slices are not directly serializable in Go.
-                      It is stored as a string but can be converted back to a slice of Endpoints.
+                      KubernetesOSBContext represents the context object for kubernetes in the OSB spec
+                      cf https://github.com/cloudfoundry/servicebroker/blob/master/profile.md#kubernetes-context-object
+                    properties:
+                      clusterId:
+                        type: string
+                      instanceAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      instanceName:
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      namespace:
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      namespaceAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      platform:
+                        enum:
+                        - kubernetes
+                        type: string
+                    required:
+                    - clusterId
+                    - instanceName
+                    - namespace
+                    - platform
+                    type: object
+                  dashboardURL:
+                    pattern: ^https?://.+
+                    type: string
+                  hasActiveBindings:
+                    type: boolean
+                  instanceId:
                     type: string
                   lastOperationDescription:
                     type: string
@@ -192,37 +236,24 @@ spec:
                       OperationKey is an extra identifier from the broker in order to provide extra
                       identifiers for asynchronous operations.
                     type: string
-                  lastOperationPolled_time:
-                    type: string
                   lastOperationState:
                     description: |-
                       LastOperationState is a typedef representing the state of an ongoing
                       operation for an instance.
                     type: string
-                  metadata:
-                    properties:
-                      expires_at:
-                        type: string
-                      renew_before:
-                        type: string
-                    type: object
+                  organizationGuid:
+                    type: string
                   parameters:
                     description: |-
                       SerializableParameters represents a JSON-encoded map of arbitrary parameters.
                       Stored as a string because slices and maps are not directly serializable in Go
                       It is stored as a string but can be converted back to a Go map.
                     type: string
-                  routeServiceUrl:
-                    pattern: ^https?://.+
+                  planId:
                     type: string
-                  syslogDrainUrl:
-                    pattern: ^https?://.+
+                  serviceId:
                     type: string
-                  volumeMounts:
-                    description: |-
-                      SerializableVolumeMounts represents a JSON-encoded slice of osb.VolumeMount.
-                      Stored as a string because slices are not directly serializable in Go.
-                      It is stored as a string but can be converted back to a slice of VolumeMounts.
+                  spaceGuid:
                     type: string
                 type: object
               conditions:

--- a/package/crds/osb.m.crossplane.io_clusterproviderconfigs.yaml
+++ b/package/crds/osb.m.crossplane.io_clusterproviderconfigs.yaml
@@ -4,35 +4,32 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: storeconfigs.m.osb.crossplane.io
+  name: clusterproviderconfigs.osb.m.crossplane.io
 spec:
-  group: m.osb.crossplane.io
+  group: osb.m.crossplane.io
   names:
     categories:
     - crossplane
-    - store
-    - osb
-    kind: StoreConfig
-    listKind: StoreConfigList
-    plural: storeconfigs
-    singular: storeconfig
-  scope: Namespaced
+    - provider
+    - kubernetes
+    kind: ClusterProviderConfig
+    listKind: ClusterProviderConfigList
+    plural: clusterproviderconfigs
+    singular: clusterproviderconfig
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
-    - jsonPath: .spec.type
-      name: TYPE
-      type: string
-    - jsonPath: .spec.defaultScope
-      name: DEFAULT-SCOPE
+    - jsonPath: .spec.credentials.secretRef.name
+      name: SECRET-NAME
+      priority: 1
       type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A StoreConfig configures how osb controller should store connection
-          details.
+        description: A ClusterProviderConfig configures a Kubernetes provider.
         properties:
           apiVersion:
             description: |-
@@ -41,6 +38,8 @@ spec:
               may reject unrecognized values.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
+          disable_async:
+            type: boolean
           kind:
             description: |-
               Kind is a string value representing the REST resource this object represents.
@@ -52,10 +51,81 @@ spec:
           metadata:
             type: object
           spec:
-            description: A StoreConfigSpec defines the desired state of a ProviderConfig.
+            description: A ProviderConfigSpec defines the desired state of a ProviderConfig.
+            properties:
+              brokerUrl:
+                description: BrokerURL to send OSB requests to
+                pattern: ^https?://.+
+                type: string
+              credentials:
+                description: Credentials required to authenticate to this provider.
+                properties:
+                  env:
+                    description: |-
+                      Env is a reference to an environment variable that contains credentials
+                      that must be used to connect to the provider.
+                    properties:
+                      name:
+                        description: Name is the name of an environment variable.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  fs:
+                    description: |-
+                      Fs is a reference to a filesystem location that contains credentials that
+                      must be used to connect to the provider.
+                    properties:
+                      path:
+                        description: Path is a filesystem path.
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  secretRef:
+                    description: |-
+                      A SecretRef is a reference to a secret key that contains the credentials
+                      that must be used to connect to the provider.
+                    properties:
+                      key:
+                        description: The key to select.
+                        type: string
+                      name:
+                        description: Name of the secret.
+                        type: string
+                      namespace:
+                        description: Namespace of the secret.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    - namespace
+                    type: object
+                  source:
+                    description: Source of the provider credentials.
+                    enum:
+                    - None
+                    - Secret
+                    - InjectedIdentity
+                    - Environment
+                    - Filesystem
+                    type: string
+                required:
+                - source
+                type: object
+              osbVersion:
+                description: OSB version is used to add error management
+                pattern: ^2\.\d{1,2}$
+                type: string
+              timeout:
+                description: Timeout to replace the default one when creating client
+                minimum: 0
+                type: integer
+            required:
+            - brokerUrl
             type: object
           status:
-            description: A StoreConfigStatus represents the status of a StoreConfig.
+            description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.
             properties:
               conditions:
                 description: Conditions of the resource.
@@ -103,8 +173,13 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              users:
+                description: Users of this provider configuration.
+                format: int64
+                type: integer
             type: object
         required:
+        - disable_async
         - spec
         type: object
     served: true

--- a/package/crds/osb.m.crossplane.io_providerconfigs.yaml
+++ b/package/crds/osb.m.crossplane.io_providerconfigs.yaml
@@ -4,19 +4,15 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: clusterproviderconfigs.m.osb.crossplane.io
+  name: providerconfigs.osb.m.crossplane.io
 spec:
-  group: m.osb.crossplane.io
+  group: osb.m.crossplane.io
   names:
-    categories:
-    - crossplane
-    - provider
-    - kubernetes
-    kind: ClusterProviderConfig
-    listKind: ClusterProviderConfigList
-    plural: clusterproviderconfigs
-    singular: clusterproviderconfig
-  scope: Cluster
+    kind: ProviderConfig
+    listKind: ProviderConfigList
+    plural: providerconfigs
+    singular: providerconfig
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
@@ -29,7 +25,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ClusterProviderConfig configures a Kubernetes provider.
+        description: A ProviderConfig configures a OSB provider.
         properties:
           apiVersion:
             description: |-

--- a/package/crds/osb.m.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/osb.m.crossplane.io_providerconfigusages.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: providerconfigusages.m.osb.crossplane.io
+  name: providerconfigusages.osb.m.crossplane.io
 spec:
-  group: m.osb.crossplane.io
+  group: osb.m.crossplane.io
   names:
     categories:
     - crossplane

--- a/package/crds/osb.m.crossplane.io_storeconfigs.yaml
+++ b/package/crds/osb.m.crossplane.io_storeconfigs.yaml
@@ -4,28 +4,35 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: providerconfigs.m.osb.crossplane.io
+  name: storeconfigs.osb.m.crossplane.io
 spec:
-  group: m.osb.crossplane.io
+  group: osb.m.crossplane.io
   names:
-    kind: ProviderConfig
-    listKind: ProviderConfigList
-    plural: providerconfigs
-    singular: providerconfig
+    categories:
+    - crossplane
+    - store
+    - osb
+    kind: StoreConfig
+    listKind: StoreConfigList
+    plural: storeconfigs
+    singular: storeconfig
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
-    - jsonPath: .spec.credentials.secretRef.name
-      name: SECRET-NAME
-      priority: 1
+    - jsonPath: .spec.type
+      name: TYPE
+      type: string
+    - jsonPath: .spec.defaultScope
+      name: DEFAULT-SCOPE
       type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ProviderConfig configures a OSB provider.
+        description: A StoreConfig configures how osb controller should store connection
+          details.
         properties:
           apiVersion:
             description: |-
@@ -34,8 +41,6 @@ spec:
               may reject unrecognized values.
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
-          disable_async:
-            type: boolean
           kind:
             description: |-
               Kind is a string value representing the REST resource this object represents.
@@ -47,81 +52,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: A ProviderConfigSpec defines the desired state of a ProviderConfig.
-            properties:
-              brokerUrl:
-                description: BrokerURL to send OSB requests to
-                pattern: ^https?://.+
-                type: string
-              credentials:
-                description: Credentials required to authenticate to this provider.
-                properties:
-                  env:
-                    description: |-
-                      Env is a reference to an environment variable that contains credentials
-                      that must be used to connect to the provider.
-                    properties:
-                      name:
-                        description: Name is the name of an environment variable.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  fs:
-                    description: |-
-                      Fs is a reference to a filesystem location that contains credentials that
-                      must be used to connect to the provider.
-                    properties:
-                      path:
-                        description: Path is a filesystem path.
-                        type: string
-                    required:
-                    - path
-                    type: object
-                  secretRef:
-                    description: |-
-                      A SecretRef is a reference to a secret key that contains the credentials
-                      that must be used to connect to the provider.
-                    properties:
-                      key:
-                        description: The key to select.
-                        type: string
-                      name:
-                        description: Name of the secret.
-                        type: string
-                      namespace:
-                        description: Namespace of the secret.
-                        type: string
-                    required:
-                    - key
-                    - name
-                    - namespace
-                    type: object
-                  source:
-                    description: Source of the provider credentials.
-                    enum:
-                    - None
-                    - Secret
-                    - InjectedIdentity
-                    - Environment
-                    - Filesystem
-                    type: string
-                required:
-                - source
-                type: object
-              osbVersion:
-                description: OSB version is used to add error management
-                pattern: ^2\.\d{1,2}$
-                type: string
-              timeout:
-                description: Timeout to replace the default one when creating client
-                minimum: 0
-                type: integer
-            required:
-            - brokerUrl
+            description: A StoreConfigSpec defines the desired state of a ProviderConfig.
             type: object
           status:
-            description: A ProviderConfigStatus reflects the observed state of a ProviderConfig.
+            description: A StoreConfigStatus represents the status of a StoreConfig.
             properties:
               conditions:
                 description: Conditions of the resource.
@@ -169,13 +103,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              users:
-                description: Users of this provider configuration.
-                format: int64
-                type: integer
             type: object
         required:
-        - disable_async
         - spec
         type: object
     served: true


### PR DESCRIPTION
Managed resources are now generated with osb.m.crossplane.io instead of m.osb.crossplane.io

Fixes #38 